### PR TITLE
update lr_scheduler

### DIFF
--- a/ssd/utils/lr_scheduler.py
+++ b/ssd/utils/lr_scheduler.py
@@ -1,3 +1,5 @@
+from bisect import bisect_right
+
 from torch.optim.lr_scheduler import MultiStepLR
 
 
@@ -6,12 +8,15 @@ class WarmupMultiStepLR(MultiStepLR):
                  warmup_iters=500, last_epoch=-1):
         self.warmup_factor = warmup_factor
         self.warmup_iters = warmup_iters
-        super().__init__(optimizer, milestones, gamma, last_epoch)
+        super(MultiStepLR, self).__init__(optimizer, milestones, gamma, last_epoch)
+        self.milestones = milestones
+        self.last_epoch = 0
 
     def get_lr(self):
-        lr = super().get_lr()
+        lr = self.base_lrs
+        warmup_factor = 1
         if self.last_epoch < self.warmup_iters:
             alpha = self.last_epoch / self.warmup_iters
             warmup_factor = self.warmup_factor * (1 - alpha) + alpha
             return [l * warmup_factor for l in lr]
-        return lr
+        return [l * warmup_factor * self.gamma ** bisect_right(self.milestones, self.last_epoch) for l in lr]


### PR DESCRIPTION
update lr_scheduler.py to make it compatible with PyTorch 1.1.0 since MultiStepLR has been changed in v1.1.0