### PR TITLE
In PyTorch >=1.1.0 call `optimizer.step()` after `lr_scheduler.step()`

### DIFF
--- a/ssd/engine/trainer.py
+++ b/ssd/engine/trainer.py
@@ -74,7 +74,6 @@ def do_train(cfg, model,
     for iteration, (images, targets, _) in enumerate(data_loader, start_iter):
         iteration = iteration + 1
         arguments["iteration"] = iteration
-        scheduler.step()
 
         images = images.to(device)
         targets = targets.to(device)
@@ -89,6 +88,7 @@ def do_train(cfg, model,
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
+        scheduler.step()
 
         batch_time = time.time() - end
         end = time.time()


### PR DESCRIPTION
Fixes following warning:

```
python3.6/site-packages/torch/optim/lr_scheduler.py:82: UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule.See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
  "https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate", UserWarning)
```