### PR TITLE
Fix undefined symbol error

### DIFF
--- a/ssd/utils/nms.py
+++ b/ssd/utils/nms.py
@@ -2,6 +2,7 @@ import warnings
 import torchvision
 
 try:
+    import torch
     import torch_extension
 
     _nms = torch_extension.nms


### PR DESCRIPTION
I have encounted undefined symbol error twice.
`undefined symbol: _ZN2at19UndefinedTensorImpl10_singletonE` and `undefined symbol: _ZN6caffe26detail37_typeMetaDataInstance_preallocated_32E`.
The error disappear when I add `import torch` before `import torch_extension`.