### PR TITLE
fix #206

### DIFF
--- a/ssd/utils/nms.py
+++ b/ssd/utils/nms.py
@@ -4,7 +4,9 @@ import warnings
 import torch
 import torchvision
 
-if torchvision.__version__ >= '0.3.0':
+from packaging import version
+
+if version.parse(torchvision.__version__) >= version.parse('0.3.0'):
     _nms = torchvision.ops.nms
 else:
     warnings.warn('No NMS is available. Please upgrade torchvision to 0.3.0+')


### PR DESCRIPTION
The current `torchvision.__version__` is 0.11.0, but `'0.3.0'` is larger than `'0.11.0'` when comparing by string. This makes an error in `ssd/utils/nms.py`. So I changed the version comparison code.